### PR TITLE
feat: Menu metadata

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -37,15 +37,16 @@ def get_menus(day=None, restaurants=None):
     else:
         requested_restaurants = [restaurant.label for restaurant in Restaurant.select()]
 
-    query = RestaurantMenu.select(Restaurant.label, RestaurantMenu.menu).join(Restaurant) \
+    query = RestaurantMenu.select(Restaurant.label, RestaurantMenu.menu, RestaurantMenu.day, Restaurant.url).join(Restaurant) \
         .where(RestaurantMenu.day == requested_date) \
         .where(Restaurant.label << requested_restaurants) \
         .dicts()
-    menus = {}
+    menus, menu_metadata = {}, {}
     for row in query:
         menus[row["label"]] = row["menu"]
+        menu_metadata[row["label"]] = {"day": row["day"].strftime("%d.%m.%Y"), "url": row["url"]}
 
-    return {"day": requested_date, "menus": [{"restaurant": restaurant, "menu": menus.get(restaurant)}
+    return {"day": requested_date, "menus": [{"restaurant": restaurant, "menu": menus.get(restaurant), "menu_metadata": menu_metadata.get(restaurant)}
                                              for restaurant in requested_restaurants]}
 
 

--- a/web/src/Restaurant.js
+++ b/web/src/Restaurant.js
@@ -4,6 +4,7 @@ import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import Chip from '@mui/material/Chip';
+import Link from '@mui/material/Link'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import PlaceTwoToneIcon from '@mui/icons-material/PlaceTwoTone';
 import Typography from '@mui/material/Typography';
@@ -34,7 +35,15 @@ class RestaurantComponent extends Component {
             }/>
           </AccordionSummary>
           <AccordionDetails>
-            <Typography>
+            <Typography>              
+              <span>
+                Aktualizováno: {this.props.metadata.day}{" - "}
+              </span>
+              <Link target="_blank" rel="noopener noreferrer" href={this.props.metadata.url} color="inherit" aria-label="Menu link">
+                Menu link
+              </Link>
+              <br/>
+              <br/>
               {this.props.menu && this.props.menu.split("\n").map((item, idx) => (
                 <span key={idx}>
                   {item}

--- a/web/src/RestaurantList.js
+++ b/web/src/RestaurantList.js
@@ -36,19 +36,27 @@ class RestaurantListComponent extends Component {
           restaurantDetailMap[restaurantObject.label] = { name: restaurantObject.name, latitude: restaurantObject.latitude, longitude: restaurantObject.longitude }
         }
         // Setup restaurant label -> menus map
+        // Setup restaurant metadata label -> menus metadata (day, url)
         const todaysMenusMap = {}
+        const todaysMenusMetadata = {}
         for (const menuObject of responseMenus.menus) {
           todaysMenusMap[menuObject.restaurant] = menuObject.menu
+          todaysMenusMetadata[menuObject.restaurant] = {
+            // using ?. so that when sync fails, app won't crash
+            "day": menuObject?.menu_metadata?.day,
+            "url": menuObject?.menu_metadata?.url,
+          }
         }
         this.setState({ restaurantDetailMap: restaurantDetailMap,
                         todaysMenusMap: todaysMenusMap,
+                        todaysMenusMetadata: todaysMenusMetadata,
                         defaultUserLocation: { latitude: originDetailMap["office"].latitude, longitude: originDetailMap["office"].longitude },
                         isLoading: false })
       });
   }
 
   render() {
-    const { isLoading, restaurantDetailMap, todaysMenusMap, defaultUserLocation } = this.state;
+    const { isLoading, restaurantDetailMap, todaysMenusMap, defaultUserLocation, todaysMenusMetadata } = this.state;
     if (isLoading || todaysMenusMap.length === 0) {
       return (
         <Container maxWidth="md">
@@ -75,7 +83,7 @@ class RestaurantListComponent extends Component {
 
     const restaurantPanels = []
     for (const restaurant of sortedRestaurants) {
-      restaurantPanels.push(<RestaurantComponent key={restaurant} detail={restaurantDetailMap[restaurant]} distance={restaurantDistanceMap[restaurant]} menu={todaysMenusMap[restaurant]}/>)
+      restaurantPanels.push(<RestaurantComponent key={restaurant} detail={restaurantDetailMap[restaurant]} distance={restaurantDistanceMap[restaurant]} menu={todaysMenusMap[restaurant]} metadata={todaysMenusMetadata[restaurant]}/>)
     }
     return (
       <Container maxWidth="md">


### PR DESCRIPTION
I am a huge fan of this project from the first time I saw it :)

Problem:
We had an issue with colleagues when a menu wasn't updated (it was probably a problem with the restaurant's website), and there was no easy way to verify that the menu was correct. We were surprised when we arrived at the restaurant and saw that the menu in the restaurant was different from the lunch picker's menu.

Solution:
For better UX, add the day of sync and a link to the restaurant's menu website, where users can easily verify the menu.
(Maybe the date is unnecessary, and just a link would be enough.)

How I tested it:
I ran the build commands and tested the website.